### PR TITLE
Update to work with Python 3

### DIFF
--- a/sources/factorio/blueprints.py
+++ b/sources/factorio/blueprints.py
@@ -12,9 +12,14 @@ import zlib
 class EncodedBlob(object):
     """one Factorio json->gzip->base64 encoded blob"""
 
-    def __init__(self, data=None, version_byte=None):
-        self.data = data or {}
-        self.version_byte = version_byte
+    def __init__(self, data=None, version_byte='0'):
+        """Default Constructor, that also takes raw data, or acts as a copy constructor"""
+        if issubclass(type(data), EncodedBlob):
+            self.data = data.data.copy()
+            self.version_byte = data.version_byte
+        else:
+            self.data = data or {}
+            self.version_byte = version_byte
 
     def __getattr__(self, attr):
         """Generically provide access to blueprint.data.blueprint.entities etc"""

--- a/sources/factorio/blueprints.py
+++ b/sources/factorio/blueprints.py
@@ -22,18 +22,29 @@ class EncodedBlob(object):
             self.version_byte = version_byte
 
     def __getattr__(self, attr):
-        """Generically provide access to blueprint.data.blueprint.entities etc"""
+        """
+        Generically provide access to blueprint.data.blueprint.entities etc
+        WARNING:  These are read only, and will silently fail if a user attempts to modify them!
+        """
         return self.inner_data.get(attr)
 
     @property
     def data_type(self):
+        """
+        Factorio blueprints (and books), have a root object, under which everything is nested.
+        This gives the name of that object.
+        """
         data_type, _ = next(iter(self.data.items()))
         return data_type
 
     @property
     def inner_data(self):
-        _, inner_data = next(iter(self.data.items()))
-        return inner_data
+        """
+        Factorio blueprints (and books), have a root object, under which everything is nested.
+        This gives access to everything under that root object without having to know its name.
+        WARNING:  This is a read only copy, and will silently fail if a user attempts to modify it!
+        """
+        return self.data[self.data_type]
 
     @classmethod
     def from_exchange_string(cls, exchange_str):

--- a/sources/factorio/blueprints.py
+++ b/sources/factorio/blueprints.py
@@ -28,6 +28,10 @@ class EncodedBlob(object):
         """
         return self.inner_data.get(attr)
 
+    def update(self, key, value):
+        """Since getattr is read only, use this to update data"""
+        self.data[self.data_type].update({key:value})
+
     @property
     def data_type(self):
         """
@@ -126,7 +130,6 @@ class Blueprint(EncodedBlob):
             name = ent["name"]
             mats[name] = mats.setdefault(name, 0) + 1
         return mats
-
 
 class BlueprintBook(EncodedBlob):
     """one Factorio blueprint book, containing zero or more blueprints"""

--- a/sources/factorio/blueprints.py
+++ b/sources/factorio/blueprints.py
@@ -50,7 +50,7 @@ class EncodedBlob(object):
     def from_exchange_string(cls, exchange_str):
         version_byte = exchange_str[0]
         decoded = base64.b64decode(exchange_str[1:])
-        json_str = zlib.decompress(decoded)
+        json_str = zlib.decompress(decoded).decode("utf8")    #Convert from bytes to str
         data = json.loads(json_str, object_pairs_hook=collections.OrderedDict)
         return cls(data = data, version_byte = version_byte)
 
@@ -66,14 +66,14 @@ class EncodedBlob(object):
 
     @classmethod
     def from_json_file(cls, filename):
-        return cls.from_json_string(open(filename).read().strip())
+        return cls.from_json_string(open(filename, encoding="utf-8").read().strip())
 
     def to_exchange_string(self, **kwargs):
         if self.version_byte is None:
             raise RuntimeError(
 		"Attempted to convert to exchange string with no version_byte")
         json_str = self.to_json_string(**kwargs)
-        compressed = zlib.compress(json_str, 9)
+        compressed = zlib.compress(json_str.encode("utf-8"), 9)
         encoded = base64.b64encode(compressed)
         return self.version_byte + encoded.decode()
 
@@ -88,12 +88,13 @@ class EncodedBlob(object):
             data,
             separators=(",", ":"),
             ensure_ascii=False,
+            indent=2,
             **kwargs
-        ).encode("utf8")
+        )
         return json_str
 
     def to_json_file(self, filename, **kwargs):
-        open(filename, "w").write(self.to_json_string(**kwargs))
+        open(filename, "w", encoding="utf-8").write(self.to_json_string(**kwargs))
 
 class Blueprint(EncodedBlob):
     """one Factorio blueprint"""

--- a/sources/factorio/blueprints.py
+++ b/sources/factorio/blueprints.py
@@ -129,6 +129,16 @@ class BlueprintBook(EncodedBlob):
 
     def __init__(self, *args, **kwargs):
         super(BlueprintBook, self).__init__(*args, **kwargs)
+        #Handle creating an empty blueprint book
+        if not self.data:
+            self.data = collections.OrderedDict()
+            self.data["blueprint_book"] = collections.OrderedDict()
+            book=self.data["blueprint_book"]
+            book['item'] = "blueprint-book"
+            book['blueprints'] = []
+            book['active_index'] = 0
+            book['label'] = "Empty Blueprint Book"
+            book['version'] = 0
         self.objectify_blueprints()
 
     def objectify_blueprints(self):

--- a/sources/factorio/blueprints.py
+++ b/sources/factorio/blueprints.py
@@ -173,3 +173,7 @@ class BlueprintBook(EncodedBlob):
         for blueprint in self.blueprints:
             blueprint.data["index"] = number
             number = number + 1
+
+    def add_blueprint(self, in_blueprint):
+        """Add a blueprint to the book"""
+        self.data["blueprint_book"]["blueprints"].append(in_blueprint)

--- a/sources/factorio/blueprints.py
+++ b/sources/factorio/blueprints.py
@@ -96,6 +96,10 @@ class EncodedBlob(object):
     def to_json_file(self, filename, **kwargs):
         open(filename, "w", encoding="utf-8").write(self.to_json_string(**kwargs))
 
+    def set_name(self, new_name):
+        """Set the blueprint/book's name"""
+        self.data[self.data_type]['label'] = new_name
+
 class Blueprint(EncodedBlob):
     """one Factorio blueprint"""
 


### PR DESCRIPTION
Also added:
* A copy constructor (to make up for python's lack of reinterpret_cast)
* A default constructor for BlueprintBook
* Some documentation warning that the simple approach is actually read only
* A function to easily change things in the blueprint or book
* A function to easily add blueprints to a book
* A function to set a blueprint or books name (convenience only, since the new `update` function would also work)

I have a fun project that I just used this for, and would probably work well here.  So, expect to see that pull request soon.